### PR TITLE
Add Docker support

### DIFF
--- a/.github/workflow/docker.yml
+++ b/.github/workflow/docker.yml
@@ -1,0 +1,23 @@
+on:
+  push:
+    branches:
+    - master
+name: Publish the Docker image
+jobs:
+  publish_image:
+    name: Publish the Docker image
+    runs-on: ubuntu-18.04
+    steps:
+    - uses: actions/checkout@f6ce2afa7079cb075a124c93c79d61779d845782
+    - name: Docker login
+      env:
+        DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
+        DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
+      run: |
+        echo ${DOCKER_PASSWORD} | docker login -u ${DOCKER_USERNAME} --password-stdin
+    - name: Docker build
+      run: |
+        docker build -t graphhopper/graphhopper-load-test-fake-backend .
+    - name: Docker push
+      run: |
+        docker push graphhopper/graphhopper-load-test-fake-backend

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,11 @@
+FROM maven:3.6.3-jdk-8 as build
+COPY pom.xml .
+COPY src/ src/
+RUN mvn package -DskipTests=true
+
+FROM openjdk:11.0.5-jre-slim
+WORKDIR /opt/backend
+COPY --from=build target/*.jar ./target/
+
+ENTRYPOINT ["java"]
+CMD ["-jar", "target/fake-server.jar"]

--- a/README.md
+++ b/README.md
@@ -11,10 +11,22 @@ Currently only the async vrp endpoint is mocked: https://docs.graphhopper.com/#o
 mvn clean package
 ```
 
-### Run
+### Run with Java
 
 ```bash
 java -jar target/fake-server.jar [-conf vertx.json]
+```
+
+### Run with Docker
+
+```bash
+docker run -p 8080:8080 graphhopper/graphhopper-load-test-fake-backend
+```
+
+### Run with Docker Compose
+
+```bash
+docker-compose up
 ```
 
 ### Example Configuration

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,10 @@
+version: '3'
+services:
+
+  fake_server:
+    hostname: fake_server
+    container_name: fake_server
+    build:
+      context: .
+    ports:
+      - 8080:8080


### PR DESCRIPTION
This adds the following support to this repo for the Java app:

* building a Docker image,
* running the server with Docker and Docker Compose,
* publishing the Docker image to Docker Hub to `graphhopper-load-test-fake-backend`.